### PR TITLE
Set up Cloud Agent dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single-service app: a TanStack Start (React 19) SSR application that runs on
+Cloudflare Workers, built with Vite. Standard commands live in `package.json` `scripts`
+and are documented in `README.md` (`pnpm dev`, `pnpm build`, `pnpm test`, `pnpm lint`,
+`pnpm fmt`, `pnpm check`). Prefer those over reinventing commands.
+
+Non-obvious caveats for this environment:
+
+- Node version: `oxlint` and `oxfmt` load `*.config.ts` files and require Node
+  `^20.19.0 || >=22.18.0`. The default `/exec-daemon/node` is v22.14.0, which is too old
+  and makes `pnpm lint` / `pnpm fmt` / `pnpm check` fail with an "Unknown file extension
+  .ts" error. During setup, nvm's default was set to Node 22 (v22.23.2) and `~/.bashrc`
+  prepends that nvm bin to `PATH` so new shells use it automatically. If a command ever
+  reports the old Node version, run `nvm use default` (or start a fresh shell).
+
+- `lefthook install` is expected to fail here. The project `postinstall` runs
+  `lefthook install`, but Cursor manages git hooks via a custom `core.hooksPath`, which
+  lefthook refuses to override. This is benign for development (it only affects local git
+  hooks). The startup update script therefore installs with `--ignore-scripts` and then
+  runs `pnpm rebuild` for the native build deps, avoiding the failing root postinstall
+  while still building `esbuild`/`workerd`/`sharp`. Do not "fix" this by forcing lefthook
+  into Cursor's hooks path.
+
+- Dev server: `pnpm dev` serves on `http://localhost:5173/` (Vite default), not 3000.
+  It renders SSR HTML directly (curling `/` returns "Hello World!"). Unknown routes render
+  the custom 404 component from `src/routes/__root.tsx`.
+
+- `pnpm test` uses Vitest with `passWithNoTests: true`, so it currently exits 0 with no
+  test files. `pnpm build` builds both the client and SSR (workerd) bundles.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for this TanStack Start + Cloudflare Workers template and documents non-obvious caveats for future agents. No application code was changed.

### What was done
- Installed dependencies with `pnpm` (Node/pnpm already present in the base image).
- Installed Node 22 (v22.23.2) via nvm and made it the shell default, because `oxlint`/`oxfmt` load `*.config.ts` and require Node `^20.19.0 || >=22.18.0` (the base `/exec-daemon/node` is v22.14.0 and fails to parse the TS configs).
- Verified the full toolchain: lint, format check, tests, production build, and the dev server.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing durable, non-obvious caveats (Node version requirement, benign `lefthook install` failure under Cursor's `core.hooksPath`, dev server port 5173, SSR behavior).

### Update (startup) script
```
pnpm install --ignore-scripts
pnpm rebuild esbuild lefthook sharp workerd
```
`--ignore-scripts` avoids the project `postinstall` (`lefthook install`), which fails because Cursor manages git hooks via a custom `core.hooksPath`. `pnpm rebuild` then runs the approved native build scripts.

### Verification

| Concern | Command | Result |
| --- | --- | --- |
| Lint | `pnpm lint` | Pass |
| Format | `pnpm fmt` | Pass (19 files) |
| Tests | `pnpm test` | Pass (Vitest, no test files, exit 0) |
| Build | `pnpm build` | Pass (client + SSR/workerd bundles) |
| Dev server | `pnpm dev` | Serves SSR "Hello World!" at `http://localhost:5173/` |

Hello-world task: loaded the SSR homepage and exercised the app's custom router 404 route (`src/routes/__root.tsx`), which renders "404" + "ページが見つかりませんでした。".

[tanstack_dev_server_hello_world_and_404.mp4](https://cursor.com/agents/bc-dbbecc98-59c6-45f3-95a5-31879788dff3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftanstack_dev_server_hello_world_and_404.mp4)
[Homepage Hello World](https://cursor.com/agents/bc-dbbecc98-59c6-45f3-95a5-31879788dff3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_home.webp)
[Custom 404 route](https://cursor.com/agents/bc-dbbecc98-59c6-45f3-95a5-31879788dff3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcustom_404_route.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbbecc98-59c6-45f3-95a5-31879788dff3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbbecc98-59c6-45f3-95a5-31879788dff3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

